### PR TITLE
less verbose default logging

### DIFF
--- a/src/GaussianMixtures.jl
+++ b/src/GaussianMixtures.jl
@@ -11,6 +11,16 @@ using Clustering
 using JLD2
 using FileIO
 using Compat
+using Logging
+
+# define a more informative info level 
+const moreInfo = LogLevel(-1)   # Info is LogLevel( 0 )
+# if you want to see more info, set up a logger (outside of this module) like
+
+# using Logging
+# more_logger = ConsoleLogger(stderr, LogLevel(-1))
+# global_logger(more_logger)
+# use package...
 
 include("compat.jl")
 include("gmmtypes.jl")

--- a/src/gmms.jl
+++ b/src/gmms.jl
@@ -68,7 +68,7 @@ end
 
 "`addhist!(::GMM, s)` adds a comment `s` to the GMMM"
 function addhist!(gmm::GaussianMixture, s::AbstractString)
-    @info(s)
+    @logmsg moreInfo s
     push!(gmm.hist, History(s))
     gmm
 end

--- a/src/train.jl
+++ b/src/train.jl
@@ -240,7 +240,9 @@ function em!(gmm::GMM, x::DataOrMatrix; nIter::Int = 10, varfloor::Float64=1e-3,
     initc = gmm.Σ
     ll = zeros(nIter)
     gmmkind = kind(gmm)
-    @info(string("Running ", nIter, " iterations EM on ", gmmkind, " cov GMM with ", ng, " Gaussians in ", d, " dimensions"))
+
+    @logmsg moreInfo "Running $nIter iterations EM on $gmmkind cov GMM with $ng Gaussians in $d dimensions"
+    
     for i=1:nIter
         ## E-step
         nₓ, ll[i], N, F, S = stats(gmm, x, parallel=true)


### PR DESCRIPTION
* I am benchmarking your package against other implementations and I need to supress printing to stderr or I measure how long that takes :wink:
* introduced a second `@info` level

```
using Logging
more_logger = ConsoleLogger(stderr, LogLevel(-1))  # Info is LogLevel( 0 )
global_logger(more_logger)
using GaussianMixtures
...
```

Here is an example of how I use it. notice that initially there is almost no ouput.

```julia
julia> d=OsRo.sdata(2,1000)
Dict{Symbol,Any} with 4 entries:
  :α    => [0.3, 0.7]
  :μ    => [2.0, 5.0]
  :σ    => [0.5, 0.7]
  :data => 1000×2 DataFrames.DataFrame…

julia> OsRo.bm_jl_GMM(d[:data].y)
GMM{Float64} with 2 components in 1 dimensions and diag covariance
Mix 1: weight 0.303336
  mean: [2.03076]
  variance: [0.215885]
Mix 2: weight 0.696664
  mean: [5.00192]
  variance: [0.507776]


julia> using Logging

julia> more_logger = ConsoleLogger(stderr, LogLevel(-1))
ConsoleLogger(Base.TTY(RawFD(0x00000011) open, 0 bytes waiting), LogLevel(-1), Logging.default_metafmt, true, 0, Dict{Any,Int64}())

julia> global_logger(more_logger)
ConsoleLogger(Base.TTY(RawFD(0x00000011) open, 0 bytes waiting), Info, Logging.default_metafmt, true, 0, Dict{Any,Int64}())

julia> OsRo.bm_jl_GMM(d[:data].y)
┌ LogLevel(-1): Running 100 iterations EM on diag cov GMM with 2 Gaussians in 1 dimensions
└ @ GaussianMixtures ~/.julia/dev/GaussianMixtures/src/train.jl:244
GMM{Float64} with 2 components in 1 dimensions and diag covariance
Mix 1: weight 0.303336
  mean: [2.03076]
  variance: [0.215885]
Mix 2: weight 0.696664
  mean: [5.00192]
  variance: [0.507776]

```