### PR TITLE
Logging issue in Pluto

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -100,9 +100,11 @@ function GMMk(n::Int, x::DataOrMatrix{T}; kind=:diag, nInit::Int=50, nIter::Int=
             xx = vcat(yy...)
         end
     end
-    if Logging.global_logger().min_level ≤ Logging.Debug
+    
+    min_level = Logging.min_enabled_level(global_logger())
+    if min_level ≤ Logging.Debug
         loglevel = :iter
-    elseif Logging.global_logger().min_level ≤ Logging.Info
+    elseif min_level ≤ Logging.Info
         loglevel = :final
     else
         loglevel = :none

--- a/test/bayes.jl
+++ b/test/bayes.jl
@@ -13,7 +13,7 @@
 	@test all( isapprox.(sqrt.(g.Σ[grps]), [5.867; 5.871],atol=0.01) )
 
 	## only do k-means
-	x = convert(Matrix,x)
+	x = Matrix(x)
 	g = GMM(8, x, kind=:full, nIter=0)
 	p = GMMprior(g.d, 1.0, 1.0)
 	v = VGMM(g, p)


### PR DESCRIPTION
- Fixed a logging issue that arises when running GaussianMixtures in a Pluto notebook. See #90 . I tested this in a notebook instance to verify the fix worked.
- Fixed a unit test error in `test/bayes.jl` test set related to a `convert` call for a `DataFrame` to `Matrix`.