### PR TITLE
fixing logging api and supporting Pluto

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -100,9 +100,10 @@ function GMMk(n::Int, x::DataOrMatrix{T}; kind=:diag, nInit::Int=50, nIter::Int=
             xx = vcat(yy...)
         end
     end
-    if Logging.global_logger().min_level ≤ Logging.Debug
+    min_level = Logging.min_enabled_level(global_logger())
+    if min_level ≤ Logging.Debug
         loglevel = :iter
-    elseif Logging.global_logger().min_level ≤ Logging.Info
+    elseif min_level ≤ Logging.Info
         loglevel = :final
     else
         loglevel = :none


### PR DESCRIPTION
When using GaussianMixtures.jl in Pluto, one receives the following error: 

```
gmm
type PlutoLogger has no field min_level
getproperty(::Main.PlutoRunner.PlutoLogger, ::Symbol)@Base.jl:42
var"#GMMk#11"(::Symbol, ::Int64, ::Int64, ::Int64, ::typeof(GaussianMixtures.GMMk), ::Int64, ::Matrix{Float64})@train.jl:103
#GMM#9@train.jl:37[inlined]
GMM@train.jl:32[inlined]
top-level scope@[Local: 1](http://localhost:1234/edit?id=eab1dbc0-9e53-11ec-1b37-75a82665b36b#)[inlined]
```

This is the same issue documented [here](https://github.com/fonsp/Pluto.jl/issues/1121) in [Pluto.jl](https://github.com/fonsp/Pluto.jl) and addressed #90 in GaussianMixtures.jl.

The issue seems to be in `src/train.jl` where `.min_level` is used, which is part of an internal api. The fix is the same as [here](https://github.com/JunoLab/Traceur.jl/pull/48), which switches out `.min_level` for the corresponding standard interface, [`Logging.min_enabled_level()](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.min_enabled_level). 

I dont think this should change anything regarding tests and all test are passing on my local machine. 

Let me know if you'd like anything else added. 
