### PR TITLE
Query current logger instead of global one (should fix #92)

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -100,14 +100,20 @@ function GMMk(n::Int, x::DataOrMatrix{T}; kind=:diag, nInit::Int=50, nIter::Int=
             xx = vcat(yy...)
         end
     end
-    min_level = Logging.min_enabled_level(global_logger())
-    if min_level ≤ Logging.Debug
-        loglevel = :iter
+
+    # Query info about the `current_logger` (not the global one),
+    # so that the user could choose a different logger:
+    #
+    # my_gmm = Logging.with_logger(Logging.NullLogger()) do GMM(...) end
+    min_level = Logging.min_enabled_level(Logging.current_logger())
+    loglevel = if min_level ≤ Logging.Debug
+        :iter
     elseif min_level ≤ Logging.Info
-        loglevel = :final
+        :final
     else
-        loglevel = :none
+        :none
     end
+
     km = Clustering.kmeans(xx'[:,:], n, maxiter=nInit, display = loglevel)
     μ::Matrix{T} = km.centers'
     if kind == :diag


### PR DESCRIPTION
# Problem

Currently fitting a GMM produces a lot of output:

```
julia> using GaussianMixtures

julia> data = [0.3*randn(200) .- 1; 0.7*randn(400) .+ 1];

julia> GMM(2, [data;;]);
[ Info: Initializing GMM, 2 Gaussians diag covariance 1 dimensions using 600 data points
K-means converged with 5 iterations (objv = 162.85171999804564)
┌ Info: K-means with 600 data points using 5 iterations
└ 150.0 data points per parameter

julia>
```

Part of this output can't be easily suppressed (see #92) because this code queries the _global_ logger:

https://github.com/davidavdav/GaussianMixtures.jl/blob/9926a1171a655a089d0cadc4b6512564186d3d0f/src/train.jl#L103

For example, this makes estimating thousands of small GMMs extremely noisy, and the only solution to silence logging seems to involve changing the global logger which isn't ideal.

# Possible solution

Query the current logger instead using [`Logging.current_logger()`](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.current_logger), which returns either the "task-local" logger or the global one if there's no local logger.

This should let users change the logger and suppress logging entirely:

```
julia> Logging.with_logger(Logging.NullLogger()) do; GMM(2, [data;;]) end;
# no output!
julia> 
```