### PR TITLE
Bump compat for StatsBase to 0.34

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ PDMats = "0.10 - 0.11"
 RDatasets = "0.6, 0.7"
 ScikitLearnBase = "0.5"
 SpecialFunctions = "1, 2"
-StatsBase = "0.33"
+StatsBase = "0.33, 0.34"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
GaussianMixtures is preventing StatsBase from updating to 0.34.
Would it be possible to adjust the compat and release a new version with the updated compat?
