### PR TITLE
Fix stalling precompilation issue from convert

### DIFF
--- a/src/gmms.jl
+++ b/src/gmms.jl
@@ -183,20 +183,13 @@ end
 
 ## some routines for conversion between float types
 #    @doc """`convert(GMM{::Type}, GMM)` convert the GMM to a different floating point type""" ->
-function Base.convert(::Type{GMM{Td}}, gmm::GMM{Ts}) where {Td,Ts}
-    Ts == Td && return gmm
+function Base.convert(::Type{GMM{Td, Cd}}, gmm::GMM{Ts, Cs}) where {Td,Cd,Ts,Cs}
+    (Ts == Td) && (Cs == Cd) && return gmm
     h = vcat(gmm.hist, History(string("Converted to ", Td)))
     w = map(Td, gmm.w)
     μ = map(Td, gmm.μ)
-    gmmkind = kind(gmm)
-    if gmmkind == :full
-        Σ = map(eltype(FullCov{Td}),  gmm.Σ)
-    elseif gmmkind == :diag
-        Σ = map(Td, gmm.Σ)
-    else
-        error("Unknown kind")
-    end
-    GMM(w, μ, Σ, h, gmm.nx)
+    Σ = map(eltype(Cd),  gmm.Σ)
+    return GMM{Td,Cd}(w, μ, Σ, h, gmm.nx)
 end
 function Base.convert(::Type{VGMM{Td}}, vg::VGMM{Ts}) where {Td,Ts}
     Ts == Td && return vg


### PR DESCRIPTION
Hey,

I've noticed that for some reason, when I try to precompile GaussianMixtures on Julia v1.11.3 (and also on v1.10.8) the precompilation hangs indefinitely. When I ctrl+c out of it, it says the last line it got stuck on was [src/gmms.jl line 186](https://github.com/davidavdav/GaussianMixtures.jl/blob/10349f95f3dd31881fc8bb78de86cb80b26e65de/src/gmms.jl#L186). 
After a little fiddling, I think the issue may have been that the convert method only used one parametric type for `GMM` and not both. Once I fixed this, the issue was resolved, so I think that works? 
I'm not as familiar with this part of the code, so would appreciate any comments/feedback!

Thanks :)